### PR TITLE
feat: track unknown models and async token cost

### DIFF
--- a/Backend-HR/src/routes/sdk.ts
+++ b/Backend-HR/src/routes/sdk.ts
@@ -275,7 +275,7 @@ const postLlmUsage: RequestHandler = async (req: Request, res: Response) => {
 
     let cost = body.cost;
     if ((!cost || cost === 0) && provider && model) {
-      cost = calculateTokenCost(provider, model, body.tokens_input, body.tokens_output);
+      cost = await calculateTokenCost(provider, model, body.tokens_input, body.tokens_output);
     }
 
     const { error } = await supabase.from('llm_usage').insert({

--- a/Backend-HR/src/services/modelRegistry.ts
+++ b/Backend-HR/src/services/modelRegistry.ts
@@ -1,0 +1,58 @@
+import { supabase } from '../lib/supabase';
+import { logger } from '../utils/logger';
+
+/**
+ * Record usage for unknown provider/model combinations.
+ * Creates a new row if it does not exist and aggregates token counts.
+ */
+export async function recordUnknownModel(
+  provider: string,
+  model: string,
+  inputTokens: number,
+  outputTokens: number
+): Promise<void> {
+  try {
+    const providerKey = provider.toLowerCase();
+    const modelKey = model.toLowerCase();
+
+    const { data, error } = await supabase
+      .from('unknown_llm_models')
+      .select('input_tokens, output_tokens')
+      .eq('provider', providerKey)
+      .eq('model', modelKey)
+      .maybeSingle();
+
+    if (error) {
+      logger.error('Failed to check unknown model:', error.message);
+      return;
+    }
+
+    if (!data) {
+      const { error: insertError } = await supabase
+        .from('unknown_llm_models')
+        .insert({
+          provider: providerKey,
+          model: modelKey,
+          input_tokens: inputTokens,
+          output_tokens: outputTokens
+        });
+      if (insertError) {
+        logger.error('Failed to insert unknown model:', insertError.message);
+      }
+    } else {
+      const { error: updateError } = await supabase
+        .from('unknown_llm_models')
+        .update({
+          input_tokens: (data.input_tokens || 0) + inputTokens,
+          output_tokens: (data.output_tokens || 0) + outputTokens
+        })
+        .eq('provider', providerKey)
+        .eq('model', modelKey);
+      if (updateError) {
+        logger.error('Failed to update unknown model:', updateError.message);
+      }
+    }
+  } catch (err: any) {
+    logger.error('Error recording unknown model:', err.message || err);
+  }
+}


### PR DESCRIPTION
## Summary
- add modelRegistry service to store unknown provider/model combos and aggregate token usage
- make calculateTokenCost async and log unknown models
- await calculateTokenCost in analytics and SDK routes

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8810cec88322b0d514562276187b