### PR TITLE
feat: guard client id override

### DIFF
--- a/Backend-HR/src/middleware/auth.ts
+++ b/Backend-HR/src/middleware/auth.ts
@@ -66,10 +66,12 @@ export async function authenticateApiKey(req: Request, res: Response, next: Next
     }
     authReq.apiKeyId = keyRow.id;
 
-    // Optional override of client id for SDK testing
-    const overrideClientId = (req.headers['x-client-id'] as string | undefined)?.trim();
-    if (overrideClientId) {
-      authReq.clientId = overrideClientId;
+    // Optional override of client id for SDK testing (non-production only)
+    if (process.env.NODE_ENV !== 'production') {
+      const overrideClientId = (req.headers['x-client-id'] as string | undefined)?.trim();
+      if (overrideClientId) {
+        authReq.clientId = overrideClientId;
+      }
     }
 
     next();


### PR DESCRIPTION
## Summary
- allow x-client-id override only outside production, preventing misuse

## Testing
- `npm test --prefix Backend-HR` *(fails: No tests found)*
- `npm run lint --prefix Backend-HR` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68add41502888322ad1f7a1726422099