### PR TITLE
refactor: reuse timestamp in error handler

### DIFF
--- a/Backend-HR/src/middleware/errorHandler.ts
+++ b/Backend-HR/src/middleware/errorHandler.ts
@@ -12,6 +12,7 @@ export const errorHandler = (
   res: Response,
   next: NextFunction
 ) => {
+  const timestamp = new Date().toISOString();
   let statusCode = err.statusCode || 500;
   let message = err.message || 'Internal Server Error';
 
@@ -22,7 +23,7 @@ export const errorHandler = (
     url: req.url,
     method: req.method,
     ip: req.ip,
-    timestamp: new Date().toISOString()
+    timestamp
   });
 
   // Handle specific error types
@@ -45,7 +46,7 @@ export const errorHandler = (
   const response: any = {
     error: message,
     status: statusCode,
-    timestamp: new Date().toISOString()
+    timestamp
   };
 
   if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
## Summary
- define a single timestamp in error handler middleware
- reuse timestamp for logging and responses

## Testing
- `npm test --prefix Backend-HR -- --passWithNoTests`
- `npm run lint --prefix Backend-HR` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68aef85936d4832285b00ef4d0d2d668