### PR TITLE
chore: rename unused next param in errorHandler middleware

### DIFF
--- a/Backend-HR/src/middleware/errorHandler.ts
+++ b/Backend-HR/src/middleware/errorHandler.ts
@@ -10,7 +10,7 @@ export const errorHandler = (
   err: CustomError,
   req: Request,
   res: Response,
-  next: NextFunction
+  _next: NextFunction
 ) => {
   let statusCode = err.statusCode || 500;
   let message = err.message || 'Internal Server Error';


### PR DESCRIPTION
## Summary
- rename Express errorHandler's unused `next` parameter to `_next`

## Testing
- `npm test -- --passWithNoTests` (Backend-HR)


------
https://chatgpt.com/codex/tasks/task_e_68aef8b2f2cc8322911305d79956d818