### PR TITLE
feat: add error response interface

### DIFF
--- a/Backend-HR/src/middleware/errorHandler.ts
+++ b/Backend-HR/src/middleware/errorHandler.ts
@@ -6,6 +6,14 @@ export interface CustomError extends Error {
   code?: string;
 }
 
+export interface ErrorResponse {
+  error: string;
+  status: number;
+  timestamp: string;
+  stack?: string;
+  details?: CustomError;
+}
+
 export const errorHandler = (
   err: CustomError,
   req: Request,
@@ -42,7 +50,7 @@ export const errorHandler = (
   }
 
   // Don't send stack trace in production
-  const response: any = {
+  const response: ErrorResponse = {
     error: message,
     status: statusCode,
     timestamp: new Date().toISOString()


### PR DESCRIPTION
## Summary
- add ErrorResponse interface to describe error handler responses
- type error handler response with ErrorResponse

## Testing
- `npm run lint --prefix Backend-HR` (fails: ESLint couldn't find a configuration file)
- `npm test --prefix Backend-HR` (fails: No tests found)

------
https://chatgpt.com/codex/tasks/task_e_68aef83141088322baa36c0092c7fee1